### PR TITLE
Supporting route match

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -16,7 +16,19 @@ const createBasicMessage = (options = {}) =>
 const createMiddleware = options => {
   return (req, res, next) => {
     try {
-      if (auth(options, req)) {
+      let enabled = true
+      let match = options.match
+      if (typeof match === 'function') {
+        enabled = match(req)
+      }
+      else if (match instanceof RegExp) {
+        enabled = match.test(req.url)
+      }
+      else if (typeof match === 'string') {
+        enabled = match === req.url 
+      }
+      
+      if (!enabled || auth(options, req)) {
         return next()
       }
     } catch (e) {


### PR DESCRIPTION
This PR featuring a new option field `match` which allows user to control whether the auth should be enabled or not based on the request url. Solves #32.

The `match` option can be either `String`, `RegExp` or `Function`. For example:
```js
basic: {
  name: 'admin',
  pass: 'pass',
  /* the auth will be enabled only on "/admin" */
  match: '/admin',
}
```
```js
basic: {
  name: 'admin',
  pass: 'pass',
  /* the auth will be enabled on "/admin" and it's all sub routes */
  match: /\/admin.*/g
}
```
```js
basic: {
  name: 'admin',
  pass: 'pass',
  /* the auth will be enabled on "/admin" and it's all sub routes */
  match({ url }) { /* the match function will receive the `req` object as it's parameter */
    return (url || '').startsWith('/admin') /* returning true to enable the auth */
  },
}
```